### PR TITLE
Proposal: accept abbreviation 'cl' for cluster

### DIFF
--- a/rwolf.ado
+++ b/rwolf.ado
@@ -35,7 +35,7 @@ syntax varlist(min=1 fv ts numeric) [if] [in] [pweight fweight aweight iweight],
  Verbose
  strata(varlist)
  otherendog(varlist)
- cluster(varlist)
+ CLuster(varlist)
  iv(varlist fv ts) 
  indepexog
  bl(name)


### PR DESCRIPTION
Dear Damian, 
thank you for your very helpful code! 

I have one minor issue: The regression commands in Stata accepts "cl" as an abbreviation for "cluster," while current rwolf requires "cluster" to be spelled out. If a user mistakenly tries to use the abbreviation, the rwolf command silently ignores the option. I propose adding the possibility of abbreviating the cluster option. 

Kind regards,
Erik